### PR TITLE
fix: catch 500 status code where alert rule does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.6.0] - 2024-11-15
+
+### Changed
+- Check for existing alert rule response in create_alert_rule.py only caught 404 in response where alert doesn't exist. We get 500 response from a "doesnt not exist" response and therefore the next step "update" fails. Extended the if to catch both 404 & 500 status codes and run "create" rather than "update".
+
+
 # [1.5.0] - 2023-11-10
 
 ### Changed

--- a/grafana_backup/constants.py
+++ b/grafana_backup/constants.py
@@ -7,5 +7,5 @@ else:
     homedir = os.environ["HOME"]
 
 PKG_NAME = "grafana-backup"
-PKG_VERSION = "1.4.2"
+PKG_VERSION = "1.6.0"
 JSON_CONFIG_PATH = "{0}/.grafana-backup.json".format(homedir)

--- a/grafana_backup/create_alert_rule.py
+++ b/grafana_backup/create_alert_rule.py
@@ -32,7 +32,7 @@ def main(args, settings, file_path):
         get_response= get_alert_rule(uid, grafana_url, http_get_headers, verify_ssl, client_cert, debug)
         status_code=get_response[0]
         print("Got a code: {0}", status_code)
-        if status_code == 404:
+        if status_code in [404, 500]:
            http_post_headers['x-disable-provenance']='*'
            result = create_alert_rule(json.dumps(alert_rule), grafana_url, http_post_headers, verify_ssl, client_cert, debug)
         else:


### PR DESCRIPTION
Updated if/else in create_alert_rule.py to catch status code 500 where an alert does not exist..

We got back 500 in this case and so the next step of "update" failed as the alert doesn't exist..

Example before -
restoring alert_rule: /tmp/tmpozo8xxg_/OUTPUT/alert_rules/202411141600/PeUtK8GNz.alert_rule
[DEBUG] resp status: 500
[DEBUG] resp body: {'message': 'could not find alert rule', 'traceID': ''}
Got a code: {0} 500
[DEBUG] resp status: 404
[DEBUG] resp body: None
create alert rule: Network IO pressure, status: 404, msg: None

Example after -
restoring alert_rule: /tmp/tmp75alqpq3/OUTPUT/alert_rules/202411141600/PeUtK8GNz.alert_rule
[DEBUG] resp status: 500
[DEBUG] resp body: {'message': 'could not find alert rule', 'traceID': ''}
Got a code: {0} 500
[DEBUG] resp status: 201
[DEBUG] resp body: {'id': 1, 'uid': 'PeUtK8GNz', 'orgID': 1, 'folderUID': 'wGSknOsSz', 'ruleGroup': 'Infra-test', 'title': 'Network IO pressure', 'condition': 'B', 'data': [{'refId': 'A', 'queryType': '', 'relativeTimeRange': {'from': 300, 'to': 0}, 'datasourceUid': 'prometheus', 'model': {'datasource': {'type': 'prometheus', 'uid': 'prometheus'}, 'expr': '', 'interval': '', 'intervalMs': 15000, 'maxDataPoints': 43200, 'refId': 'A'}}, {'refId': 'B', 'queryType': '', 'relativeTimeRange': {'from': 0, 'to': 0}, 'datasourceUid': '-100', 'model': {'conditions': [{'evaluator': {'params': [3], 'type': 'gt'}, 'operator': {'type': 'and'}, 'query': {'params': ['A']}, 'reducer': {'params': [], 'type': 'last'}, 'type': 'query'}], 'datasource': {'type': 'expr', 'uid': '-100'}, 'hide': False, 'intervalMs': 1000, 'maxDataPoints': 43200, 'refId': 'B', 'type': 'classic_conditions'}}], 'updated': '2024-11-15T11:28:14.754595339Z', 'noDataState': 'NoData', 'execErrState': 'Alerting', 'for': '5m', 'annotations': {'dashboardUid': 'WcJBhiqMk', 'panelId': '22'}, 'isPaused': False}
create alert rule: Network IO pressure, status: 201, msg: {'id': 1, 'uid': 'PeUtK8GNz', 'orgID': 1, 'folderUID': 'wGSknOsSz', 'ruleGroup': 'Infra-test', 'title': 'Network IO pressure', 'condition': 'B', 'data': [{'refId': 'A', 'queryType': '', 'relativeTimeRange': {'from': 300, 'to': 0}, 'datasourceUid': 'prometheus', 'model': {'datasource': {'type': 'prometheus', 'uid': 'prometheus'}, 'expr': '', 'interval': '', 'intervalMs': 15000, 'maxDataPoints': 43200, 'refId': 'A'}}, {'refId': 'B', 'queryType': '', 'relativeTimeRange': {'from': 0, 'to': 0}, 'datasourceUid': '-100', 'model': {'conditions': [{'evaluator': {'params': [3], 'type': 'gt'}, 'operator': {'type': 'and'}, 'query': {'params': ['A']}, 'reducer': {'params': [], 'type': 'last'}, 'type': 'query'}], 'datasource': {'type': 'expr', 'uid': '-100'}, 'hide': False, 'intervalMs': 1000, 'maxDataPoints': 43200, 'refId': 'B', 'type': 'classic_conditions'}}], 'updated': '2024-11-15T11:28:14.754595339Z', 'noDataState': 'NoData', 'execErrState': 'Alerting', 'for': '5m', 'annotations': {'dashboardUid': 'WcJBhiqMk', 'panelId': '22'}, 'isPaused': False}
