### PR TITLE
fix: support latest version API

### DIFF
--- a/grafana_backup/dashboardApi.py
+++ b/grafana_backup/dashboardApi.py
@@ -13,8 +13,8 @@ def health_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
 
 
 def auth_check(grafana_url, http_get_headers, verify_ssl, client_cert, debug):
-    url = '{0}/api/auth/keys'.format(grafana_url)
-    print("\n[Pre-Check] grafana auth check: {0}".format(url))
+    url = '{0}/api/org'.format(grafana_url)
+    print("\n[Pre-Check] grafana auth check using service token: {0}".format(url))
     return send_grafana_get(url, http_get_headers, verify_ssl, client_cert, debug)
 
 


### PR DESCRIPTION
### Changes
* Replace `auth_check` endpoint (`/api/auth/keys` is deprecated)
* Handle new dashboard API response

### Context

Auth keys are deprecated - use service account tokens instead

Dashboard API response is now handled as a dictionary. Replace how this is handled
